### PR TITLE
Use block temperature for Tough as Nails

### DIFF
--- a/src/main/java/cc/cassian/immersiveoverlays/compat/ToughAsNailsCompat.java
+++ b/src/main/java/cc/cassian/immersiveoverlays/compat/ToughAsNailsCompat.java
@@ -6,8 +6,8 @@ import toughasnails.api.temperature.TemperatureLevel;
 
 public class ToughAsNailsCompat {
     public static String getAmbientTemperature(LocalPlayer player) {
-      TemperatureLevel temperatureForPlayer = TemperatureHelper.getTemperatureForPlayer(player);
-        return temperatureForPlayer.name();
+        TemperatureLevel temperature = TemperatureHelper.getTemperatureAtPos(player.level(), player.blockPosition());
+        return temperature.name();
     }
 
     public static boolean isTemperatureEnabled() {


### PR DESCRIPTION
Uses the block temperature instead of the player temperature for Tough as Nails compatibility. (Tough as Nails already has an indicator for player temperature, and the thermometer shows the block temperature as well, not the player temperature)

https://github.com/user-attachments/assets/58756c84-d3df-4c07-9ed2-cf79d0f39917

